### PR TITLE
Update Description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ LazyData: true
 Depends: R (>= 4.0)
 Imports: 
     abind, 
-    BiocManager (=3.1.4)
+    BiocManager (=3.1.4),
     colorRamps,
     ellipse,
     ggplot2, 


### PR DESCRIPTION
There was a missing comma between the package dependency imports (after BiocManager) which prevented the installation of the metabom8 package on R.

Co-authored-by: Vimalnath Nambiar <vnathnambiar@hotmail.com>
Co-authored-by: Monique Ryan <monique.ryan@murdoch.edu.au>